### PR TITLE
silence clang -Wswitch warnings

### DIFF
--- a/src/cpp-code.cc
+++ b/src/cpp-code.cc
@@ -175,6 +175,8 @@ void CPPCodeGenerator::keyDimension(Printer & p, const ir::Key & key,
       keyDimension(p, key, *dimension.next, dimensions, t + 1);
       p << tab(t + 1) << "break;" << "\n";
     }
+  } else {
+    p << tab(t) << "default: break;" << "\n";
   }
 
   if ( ! (dimension.skip || dimension.values.empty())) {


### PR DESCRIPTION
@sc0ttbeardsley this PR silence C++ `-Wswitch` warnings

```
configuration.cc:107:13: warning: enumeration values 'NONE', 'PT_BR', and 'EN_UK' not handled in switch [-Wswitch]
    switch (context.language) {
```
